### PR TITLE
fix: plugin doesn't work with the current version of PL 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ For example, if we want to preview a button pattern with a gray wrapper, you hav
 title: Button
 wrap_in: gray
 ---
+
+[Insert description here]
 ```
 
 This results in an additional `<div class="sg-wrapper-gray">` element around the rendered pattern - but only in the standalone view and not if this pattern is included as an partial in other patterns.

--- a/index.js
+++ b/index.js
@@ -17,16 +17,20 @@ function writeConfigToOutput(patternlab, pluginConfig) {
   }
 }
 
-function wrapPatternPartialCode(patternlab, pattern) {
+function wrapPattern(pattern) {
   const patternData = JSON.parse(pattern.patternData);
   if (patternData.extraOutput && patternData.extraOutput.wrap_in) {
     pattern.patternPartialCode = '<div class="sg-wrapper-' + patternData.extraOutput.wrap_in + '">' + pattern.patternPartialCode + '</div>';
   }
 }
 
-async function onPatternIterate(params) {
-  const [patternlab, pattern] = params;
-  await wrapPatternPartialCode(patternlab, pattern);
+function onPatternIterate(patternlab, pattern) {
+  // Patternlab >=5 will supply arguments as an array
+  if (typeof pattern === 'undefined') {
+    pattern = patternlab[1];
+  }
+
+  wrapPattern(pattern);
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -17,11 +17,16 @@ function writeConfigToOutput(patternlab, pluginConfig) {
   }
 }
 
-function onPatternIterate(patternlab, pattern) {
+function wrapPatternPartialCode(patternlab, pattern) {
   const patternData = JSON.parse(pattern.patternData);
   if (patternData.extraOutput && patternData.extraOutput.wrap_in) {
     pattern.patternPartialCode = '<div class="sg-wrapper-' + patternData.extraOutput.wrap_in + '">' + pattern.patternPartialCode + '</div>';
   }
+}
+
+async function onPatternIterate(params) {
+  const [patternlab, pattern] = params;
+  await wrapPatternPartialCode(patternlab, pattern);
 }
 
 /**


### PR DESCRIPTION
error on console: "TypeError: Cannot read property 'patternData' of undefined"

I am using Pattern Lab Node `v5.10.1` on Mac OS, with Node `v13.12.0`, using `@pattern-lab/edition-node` Edition.