### PR TITLE
feat: adding the possibility to change the classes prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,24 @@ This results in an additional `<div class="sg-wrapper-gray">` element around the
 ## Enabling / Disabling the Plugin
 
 After install, you may manually enable or disable the plugin by finding the `plugin-node-wrappable` key within your main Pattern Lab project's `patternlab-config.json` file and setting the `enabled` flag. In the future this will be possible via CLI.
+
+## Individual class prefix
+
+After install, you may manually enable or disable the plugin by finding the `plugin-node-wrappable` key within your main Pattern Lab project's `patternlab-config.json` file and setting the `enabled` flag.
+
+In case that you'd like to change the default `sg-wrapper-` prefix for the class on the `div` wrapper HTML tag, you could configure that one within your main Pattern Lab project's `patternlab-config.json` under the `plugin-node-wrappable` keys `config` entry, for example like this:
+
+``` json
+"plugins": {
+  "plugin-node-wrappable": {
+    "enabled": true,
+    "initialized": false,
+    "prefix": "pl-wrapper-"
+  }
+}
+```
+
+This would render the wrapping HTML tag like this:
+``` html
+<div class="pl-wrapper-gray">
+```

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ function writeConfigToOutput(patternlab, pluginConfig) {
 function onPatternIterate(patternlab, pattern) {
   const patternData = JSON.parse(pattern.patternData);
   if (patternData.extraOutput && patternData.extraOutput.wrap_in) {
-    pattern.patternPartialCode = '<div class="sg-wrapper-' + patternData.extraOutput.wrap_in + '">' + pattern.patternPartialCode + '</div>';
+    const prefix = patternlab.config.plugins[pluginName].prefix || "sg-wrapper-";
+    pattern.patternPartialCode = '<div class="' + prefix + patternData.extraOutput.wrap_in + '">' + pattern.patternPartialCode + '</div>';
   }
 }
 


### PR DESCRIPTION
I am using Pattern Lab Node `v5.10.1` on Mac OS, with Node `v13.12.0`, using `@pattern-lab/edition-node` Edition.

It would be nice if the developer could change the prefix of the class by the wrapping `div` HTML tag.